### PR TITLE
Overwrite AxPROT signal for RAM access

### DIFF
--- a/IP/axi_offset/src/axi_offset.v
+++ b/IP/axi_offset/src/axi_offset.v
@@ -107,7 +107,9 @@ module axi_offset #(
 
 assign M_AXI_araddr = {HIGHEST_ADDR_BIT[0],S_AXI_araddr[ADDRESS_WIDTH-2:0]};
 assign M_AXI_arlen = S_AXI_arlen;
-assign M_AXI_arprot = S_AXI_arprot;
+
+// overwrite arprot with "Secure Data Unpriviledged" to prevent DECERR returned by memory controller of the PYNQ 
+assign M_AXI_arprot = 3'b000;
 assign M_AXI_arsize = S_AXI_arsize;
 assign M_AXI_arburst = S_AXI_arburst;
 assign M_AXI_arlock = S_AXI_arlock;
@@ -120,7 +122,9 @@ assign M_AXI_arvalid = S_AXI_arvalid;
 
 assign M_AXI_awaddr = {HIGHEST_ADDR_BIT[0],S_AXI_awaddr[ADDRESS_WIDTH-2:0]};
 assign M_AXI_awlen = S_AXI_awlen;
-assign M_AXI_awprot = S_AXI_awprot;
+
+// overwrite awprot with "Secure Data Unpriviledged" to prevent DECERR returned by memory controller of the PYNQ 
+assign M_AXI_awprot = 3'b000;
 assign M_AXI_awsize = S_AXI_awsize;
 assign M_AXI_awburst = S_AXI_awburst;
 assign M_AXI_awlock = S_AXI_awlock;


### PR DESCRIPTION
Use always AxPROT=0 (Secure Data Unprivileged) for memory accesses to the RAM. Otherwise the memory controller on the PYNQ returns DECERR and the read/write fails. This only affects the VexRISCV core, the other cores use AxPROT=0 anyway.

This closes issue #8 