### PR TITLE
swerv: Update setup of RISC-V since renaming of original repository

### DIFF
--- a/riscv/swerv/package.tcl
+++ b/riscv/swerv/package.tcl
@@ -12,7 +12,7 @@ set_property file_type {Verilog Header} [get_files swerv_eh1/configs/snapshots/d
 # optionally remove unneeded files
 
 update_compile_order -fileset sources_1
-set_property top swerv_wrapper_verilog [current_fileset]
+set_property top veer_wrapper_verilog [current_fileset]
 update_compile_order -fileset sources_1
 
 ipx::package_project -root_dir [pwd]/swerv_eh1 -import_files -force

--- a/riscv/swerv/setup.sh
+++ b/riscv/swerv/setup.sh
@@ -7,7 +7,7 @@ cd swerv_eh1
 git apply ../swerv_tapasco.patch
 export RV_ROOT=$(pwd)
 cd configs
-./swerv.config -unset=assert_on -set=fpga_optimize=1 -set reset_vec=0x0 -set dccm_enable=1 -set iccm_enable=1 -set icache_enable=1
+./veer.config -unset=assert_on -set=fpga_optimize=1 -set reset_vec=0x0 -set dccm_enable=1 -set iccm_enable=1 -set icache_enable=1
 cd ../..
 vivado -nolog -nojournal -mode batch -source package.tcl
 

--- a/riscv/swerv/swerv_tapasco.patch
+++ b/riscv/swerv/swerv_tapasco.patch
@@ -187,10 +187,10 @@ index 55acd10..9ad6596 100644
  //********************************************************************************
  // SPDX-License-Identifier: Apache-2.0
  // Copyright 2019 Western Digital Corporation or its affiliates.
-diff --git a/design/include/swerv_types.sv b/design/include/swerv_types.sv
+diff --git a/design/include/veer_types.sv b/design/include/veer_types.sv
 index f66be3f..1f52192 100644
---- a/design/include/swerv_types.sv
-+++ b/design/include/swerv_types.sv
+--- a/design/include/veer_types.sv
++++ b/design/include/veer_types.sv
 @@ -1,3 +1,4 @@
 +`include "common_defines.vh"
  // SPDX-License-Identifier: Apache-2.0
@@ -358,25 +358,25 @@ index 204da31..5a72d4d 100644
  //********************************************************************************
  // SPDX-License-Identifier: Apache-2.0
  // Copyright 2019 Western Digital Corporation or its affiliates.
-diff --git a/design/swerv.sv b/design/swerv.sv
+diff --git a/design/veer.sv b/design/veer.sv
 index 4d0bcd2..4bfb66c 100644
---- a/design/swerv.sv
-+++ b/design/swerv.sv
+--- a/design/veer.sv
++++ b/design/veer.sv
 @@ -1,3 +1,4 @@
 +`include "common_defines.vh"
  // SPDX-License-Identifier: Apache-2.0
  // Copyright 2019 Western Digital Corporation or its affiliates.
  //
-diff --git a/design/swerv_wrapper.sv b/design/swerv_wrapper.sv
+diff --git a/design/veer_wrapper.sv b/design/veer_wrapper.sv
 index ed9097e..4500c60 100644
---- a/design/swerv_wrapper.sv
-+++ b/design/swerv_wrapper.sv
+--- a/design/veer_wrapper.sv
++++ b/design/veer_wrapper.sv
 @@ -1,3 +1,4 @@
 +`include "common_defines.vh"
  // SPDX-License-Identifier: Apache-2.0
  // Copyright 2019 Western Digital Corporation or its affiliates.
  //
-@@ -305,11 +306,20 @@ module swerv_wrapper
+@@ -305,11 +306,20 @@ module veer_wrapper
     output logic [1:0] dec_tlu_perfcnt3,
  
     // ports added by the soc team
@@ -397,7 +397,7 @@ index ed9097e..4500c60 100644
     // external MPC halt/run interface
     input logic mpc_debug_halt_req, // Async halt request
     input logic mpc_debug_run_req, // Async run request
-@@ -394,12 +404,14 @@ module swerv_wrapper
+@@ -394,12 +404,14 @@ module veer_wrapper
     logic        icm_clk_override;
     logic        dec_tlu_core_ecc_disable;
  
@@ -411,8 +411,8 @@ index ed9097e..4500c60 100644
 +`endif
  
  
-    // Instantiate the swerv core
-@@ -413,6 +425,7 @@ module swerv_wrapper
+    // Instantiate the veer core
+@@ -413,6 +425,7 @@ module veer_wrapper
          .*
          );
  
@@ -420,7 +420,7 @@ index ed9097e..4500c60 100644
    // Instantiate the JTAG/DMI
     dmi_wrapper  dmi_wrapper (
             // JTAG signals
-@@ -434,6 +447,7 @@ module swerv_wrapper
+@@ -434,6 +447,7 @@ module veer_wrapper
             .reg_wr_en   (dmi_reg_wr_en),   // 1 bit  Write enable to Processor
             .dmi_hard_reset   (dmi_hard_reset)   //a hard reset of the DTM, causing the DTM to forget about any outstanding DMI transactions
     );
@@ -428,13 +428,13 @@ index ed9097e..4500c60 100644
  
  endmodule
  
-diff --git a/design/swerv_wrapper_verilog.v b/design/swerv_wrapper_verilog.v
+diff --git a/design/veer_wrapper_verilog.v b/design/veer_wrapper_verilog.v
 new file mode 100644
-index 0000000..a1c9c6c
+index 0000000..b21f6ca
 --- /dev/null
-+++ b/design/swerv_wrapper_verilog.v
++++ b/design/veer_wrapper_verilog.v
 @@ -0,0 +1,510 @@
-+// Verilog wrapper for SweRV
++// Verilog wrapper for veer
 +// 
 +// Copyright 2022 Carsten Heinz
 +// 
@@ -452,7 +452,7 @@ index 0000000..a1c9c6c
 +
 +`include "common_defines.vh"
 +
-+module swerv_wrapper_verilog (
++module veer_wrapper_verilog (
 +	input wire clk,
 +	input wire rst_n,
 +	input wire timer_int,
@@ -694,7 +694,7 @@ index 0000000..a1c9c6c
 +wire scan_mode = 1'b0; // To enable scan mode
 +wire mbist_mode = 1'b0; // to enable mbist
 +
-+swerv_wrapper swerv_wrapper_inst
++veer_wrapper veer_wrapper_inst
 +(
 +	.clk(clk),
 +	.rst_l(rst_n),


### PR DESCRIPTION
## What this MR do?

Update the setup of `swerv` to work with the renaming of the repository [`Cores-VeeR-EH1`](https://github.com/chipsalliance/Cores-VeeR-EH1). This solve #29 

## Summary of changes:

- Change `swerv` to `veer` in the package, setup and patch files.
- Update `veer_wrapper_verilog` to work with the new name