### PR TITLE
Do static linking for PE firmware

### DIFF
--- a/programming/examples/PE/Makefile
+++ b/programming/examples/PE/Makefile
@@ -21,7 +21,7 @@ ifeq (${GCCVERSIONGTEQ12},1)
 endif
 
 PROGRAM?=simple_sum
-RV_FLAGS+= -march=$(MARCH) -mabi=$(MABI) -nostdlib -g
+RV_FLAGS+= -march=$(MARCH) -mabi=$(MABI) -static -nostdlib -g
 
 ifeq ($(CCM),1)
 	# CCM is active, so we need to configure for different cores


### PR DESCRIPTION
Resolves linker error "error: PHDR segment not covered by LOAD segment"

Issue observed on Ubuntu 22.04 with `ld` 2.38. 