### PR TITLE
Versal support, related fixes

### DIFF
--- a/IP/AXIGate/AXIGate_SizedFIFO.v
+++ b/IP/AXIGate/AXIGate_SizedFIFO.v
@@ -55,7 +55,7 @@
 
 
 // Sized fifo.  Model has output register which improves timing
-module SizedFIFO(CLK, RST, D_IN, ENQ, FULL_N, D_OUT, DEQ, EMPTY_N, CLR);
+module AXIGate_SizedFIFO(CLK, RST, D_IN, ENQ, FULL_N, D_OUT, DEQ, EMPTY_N, CLR);
    parameter               p1width = 1; // data width
    parameter               p2depth = 3;
    parameter               p3cntr_width = 1; // log(p2depth-1)
@@ -85,7 +85,6 @@ module SizedFIFO(CLK, RST, D_IN, ENQ, FULL_N, D_OUT, DEQ, EMPTY_N, CLR);
 
    // if the depth is too small, don't create an ill-sized array;
    // instead, make a 1-sized array and let the initial block report an error
-   (* RAM_STYLE = "DISTRIBUTED" *)
    reg [p1width - 1 : 0]     arr[0: p2depth2];
 
    reg [p1width - 1 : 0]     D_OUT;

--- a/IP/AXIGate/component.xml
+++ b/IP/AXIGate/component.xml
@@ -1116,19 +1116,19 @@
     <spirit:fileSet>
       <spirit:name>xilinx_anylanguagesynthesis_view_fileset</spirit:name>
       <spirit:file>
-        <spirit:name>SizedFIFO.v</spirit:name>
+        <spirit:name>AXIGate_SizedFIFO.v</spirit:name>
         <spirit:fileType>verilogSource</spirit:fileType>
       </spirit:file>
       <spirit:file>
         <spirit:name>mkAXIGate.v</spirit:name>
         <spirit:fileType>verilogSource</spirit:fileType>
-        <spirit:userFileType>CHECKSUM_18227af8</spirit:userFileType>
+        <spirit:userFileType>CHECKSUM_c8d90a4f</spirit:userFileType>
       </spirit:file>
     </spirit:fileSet>
     <spirit:fileSet>
       <spirit:name>xilinx_anylanguagebehavioralsimulation_view_fileset</spirit:name>
       <spirit:file>
-        <spirit:name>SizedFIFO.v</spirit:name>
+        <spirit:name>AXIGate_SizedFIFO.v</spirit:name>
         <spirit:fileType>verilogSource</spirit:fileType>
       </spirit:file>
       <spirit:file>
@@ -1181,6 +1181,7 @@
         <xilinx:family xilinx:lifeCycle="Production">kintexuplus</xilinx:family>
         <xilinx:family xilinx:lifeCycle="Production">zynquplus</xilinx:family>
         <xilinx:family xilinx:lifeCycle="Production">kintexu</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">versal</xilinx:family>
       </xilinx:supportedFamilies>
       <xilinx:taxonomies>
         <xilinx:taxonomy>/UserIP</xilinx:taxonomy>

--- a/IP/AXIGate/mkAXIGate.v
+++ b/IP/AXIGate/mkAXIGate.v
@@ -453,7 +453,7 @@ module mkAXIGate(CLK,
   assign maxi_bready = wr_m_out$FULL_N ;
 
   // submodule rd_m_in
-  SizedFIFO #(.p1width(32'd35),
+  AXIGate_SizedFIFO #(.p1width(32'd35),
 	      .p2depth(32'd8),
 	      .p3cntr_width(32'd3),
 	      .guarded(32'd1)) rd_m_in(.RST(RST_N),
@@ -467,7 +467,7 @@ module mkAXIGate(CLK,
 				       .EMPTY_N(rd_m_in$EMPTY_N));
 
   // submodule rd_m_out
-  SizedFIFO #(.p1width(32'd34),
+  AXIGate_SizedFIFO #(.p1width(32'd34),
 	      .p2depth(32'd8),
 	      .p3cntr_width(32'd3),
 	      .guarded(32'd1)) rd_m_out(.RST(RST_N),
@@ -481,7 +481,7 @@ module mkAXIGate(CLK,
 					.EMPTY_N(rd_m_out$EMPTY_N));
 
   // submodule rd_s_in
-  SizedFIFO #(.p1width(32'd35),
+  AXIGate_SizedFIFO #(.p1width(32'd35),
 	      .p2depth(32'd8),
 	      .p3cntr_width(32'd3),
 	      .guarded(32'd1)) rd_s_in(.RST(RST_N),
@@ -495,7 +495,7 @@ module mkAXIGate(CLK,
 				       .EMPTY_N(rd_s_in$EMPTY_N));
 
   // submodule rd_s_out
-  SizedFIFO #(.p1width(32'd34),
+  AXIGate_SizedFIFO #(.p1width(32'd34),
 	      .p2depth(32'd8),
 	      .p3cntr_width(32'd3),
 	      .guarded(32'd1)) rd_s_out(.RST(RST_N),
@@ -509,7 +509,7 @@ module mkAXIGate(CLK,
 					.EMPTY_N(rd_s_out$EMPTY_N));
 
   // submodule wr_m_in
-  SizedFIFO #(.p1width(32'd71),
+  AXIGate_SizedFIFO #(.p1width(32'd71),
 	      .p2depth(32'd8),
 	      .p3cntr_width(32'd3),
 	      .guarded(32'd1)) wr_m_in(.RST(RST_N),
@@ -523,7 +523,7 @@ module mkAXIGate(CLK,
 				       .EMPTY_N(wr_m_in$EMPTY_N));
 
   // submodule wr_m_out
-  SizedFIFO #(.p1width(32'd2),
+  AXIGate_SizedFIFO #(.p1width(32'd2),
 	      .p2depth(32'd8),
 	      .p3cntr_width(32'd3),
 	      .guarded(32'd1)) wr_m_out(.RST(RST_N),
@@ -537,7 +537,7 @@ module mkAXIGate(CLK,
 					.EMPTY_N(wr_m_out$EMPTY_N));
 
   // submodule wr_s_in
-  SizedFIFO #(.p1width(32'd71),
+  AXIGate_SizedFIFO #(.p1width(32'd71),
 	      .p2depth(32'd8),
 	      .p3cntr_width(32'd3),
 	      .guarded(32'd1)) wr_s_in(.RST(RST_N),
@@ -551,7 +551,7 @@ module mkAXIGate(CLK,
 				       .EMPTY_N(wr_s_in$EMPTY_N));
 
   // submodule wr_s_out
-  SizedFIFO #(.p1width(32'd2),
+  AXIGate_SizedFIFO #(.p1width(32'd2),
 	      .p2depth(32'd8),
 	      .p3cntr_width(32'd3),
 	      .guarded(32'd1)) wr_s_out(.RST(RST_N),

--- a/IP/Controller/component.xml
+++ b/IP/Controller/component.xml
@@ -793,19 +793,19 @@
     <spirit:fileSet>
       <spirit:name>xilinx_anylanguagesynthesis_view_fileset</spirit:name>
       <spirit:file>
-        <spirit:name>src/SizedFIFO.v</spirit:name>
+        <spirit:name>src/RVController_SizedFIFO.v</spirit:name>
         <spirit:fileType>verilogSource</spirit:fileType>
       </spirit:file>
       <spirit:file>
         <spirit:name>src/mkRVController.v</spirit:name>
         <spirit:fileType>verilogSource</spirit:fileType>
-        <spirit:userFileType>CHECKSUM_5f99ab61</spirit:userFileType>
+        <spirit:userFileType>CHECKSUM_3b6e92c2</spirit:userFileType>
       </spirit:file>
     </spirit:fileSet>
     <spirit:fileSet>
       <spirit:name>xilinx_anylanguagebehavioralsimulation_view_fileset</spirit:name>
       <spirit:file>
-        <spirit:name>src/SizedFIFO.v</spirit:name>
+        <spirit:name>src/RVController_SizedFIFO.v</spirit:name>
         <spirit:fileType>verilogSource</spirit:fileType>
       </spirit:file>
       <spirit:file>
@@ -852,6 +852,7 @@
         <xilinx:family xilinx:lifeCycle="Pre-Production">virtexuplus</xilinx:family>
         <xilinx:family xilinx:lifeCycle="Pre-Production">kintexuplus</xilinx:family>
         <xilinx:family xilinx:lifeCycle="Pre-Production">kintexu</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">versal</xilinx:family>
       </xilinx:supportedFamilies>
       <xilinx:taxonomies>
         <xilinx:taxonomy>/UserIP</xilinx:taxonomy>

--- a/IP/Controller/src/RVController_SizedFIFO.v
+++ b/IP/Controller/src/RVController_SizedFIFO.v
@@ -55,7 +55,7 @@
 
 
 // Sized fifo.  Model has output register which improves timing
-module SizedFIFO(CLK, RST, D_IN, ENQ, FULL_N, D_OUT, DEQ, EMPTY_N, CLR);
+module RVController_SizedFIFO(CLK, RST, D_IN, ENQ, FULL_N, D_OUT, DEQ, EMPTY_N, CLR);
    parameter               p1width = 1; // data width
    parameter               p2depth = 3;
    parameter               p3cntr_width = 1; // log(p2depth-1)
@@ -85,6 +85,7 @@ module SizedFIFO(CLK, RST, D_IN, ENQ, FULL_N, D_OUT, DEQ, EMPTY_N, CLR);
 
    // if the depth is too small, don't create an ill-sized array;
    // instead, make a 1-sized array and let the initial block report an error
+   (* RAM_STYLE = "DISTRIBUTED" *)
    reg [p1width - 1 : 0]     arr[0: p2depth2];
 
    reg [p1width - 1 : 0]     D_OUT;

--- a/IP/Controller/src/mkRVController.v
+++ b/IP/Controller/src/mkRVController.v
@@ -363,7 +363,7 @@ module mkRVController(CLK,
   assign saxi_bresp = wr_s_out$EMPTY_N ? wr_s_out$D_OUT : 2'd0 ;
 
   // submodule rd_s_in
-  SizedFIFO #(.p1width(32'd35),
+  RVController_SizedFIFO #(.p1width(32'd35),
 	      .p2depth(32'd8),
 	      .p3cntr_width(32'd3),
 	      .guarded(32'd1)) rd_s_in(.RST(RST_N),
@@ -377,7 +377,7 @@ module mkRVController(CLK,
 				       .EMPTY_N(rd_s_in$EMPTY_N));
 
   // submodule rd_s_out
-  SizedFIFO #(.p1width(32'd34),
+  RVController_SizedFIFO #(.p1width(32'd34),
 	      .p2depth(32'd8),
 	      .p3cntr_width(32'd3),
 	      .guarded(32'd1)) rd_s_out(.RST(RST_N),
@@ -391,7 +391,7 @@ module mkRVController(CLK,
 					.EMPTY_N(rd_s_out$EMPTY_N));
 
   // submodule wr_s_in
-  SizedFIFO #(.p1width(32'd71),
+  RVController_SizedFIFO #(.p1width(32'd71),
 	      .p2depth(32'd8),
 	      .p3cntr_width(32'd3),
 	      .guarded(32'd1)) wr_s_in(.RST(RST_N),
@@ -405,7 +405,7 @@ module mkRVController(CLK,
 				       .EMPTY_N(wr_s_in$EMPTY_N));
 
   // submodule wr_s_out
-  SizedFIFO #(.p1width(32'd2),
+  RVController_SizedFIFO #(.p1width(32'd2),
 	      .p2depth(32'd8),
 	      .p3cntr_width(32'd3),
 	      .guarded(32'd1)) wr_s_out(.RST(RST_N),

--- a/IP/axi_ctrl/component.xml
+++ b/IP/axi_ctrl/component.xml
@@ -1576,6 +1576,7 @@
         <xilinx:family xilinx:lifeCycle="Production">kintexuplus</xilinx:family>
         <xilinx:family xilinx:lifeCycle="Production">zynquplus</xilinx:family>
         <xilinx:family xilinx:lifeCycle="Production">kintexu</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">versal</xilinx:family>
       </xilinx:supportedFamilies>
       <xilinx:taxonomies>
         <xilinx:taxonomy>/BaseIP</xilinx:taxonomy>

--- a/IP/axi_offset/component.xml
+++ b/IP/axi_offset/component.xml
@@ -2415,6 +2415,7 @@
         <xilinx:family xilinx:lifeCycle="Production">virtexuplus58g</xilinx:family>
         <xilinx:family xilinx:lifeCycle="Production">kintexuplus</xilinx:family>
         <xilinx:family xilinx:lifeCycle="Production">kintexu</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">versal</xilinx:family>
       </xilinx:supportedFamilies>
       <xilinx:taxonomies>
         <xilinx:taxonomy>/BaseIP</xilinx:taxonomy>

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
 SHELL=/bin/bash
-BRAM_SIZE?=0x4000
+
 PYNQ=xc7z020clg400-1
+TAPASCO_PLATFORM=
+VERSAL=false
+
+#PYNQ=xcv80-lsva4737-2MHP-e-S
+#TAPASCO_PLATFORM=-p v80
+#VERSAL=true
+
+BRAM_SIZE?=0x4000
 XLEN?=32
 CACHE?=false
 MAXI?=1
+LOCALMEM?=true
 
 ifndef TAPASCO_HOME
 $(error TAPASCO_HOME is not set, make sure to source setup.sh in TaPaSCo dir)
@@ -26,9 +35,9 @@ list:
 	@echo $(CORE_LIST)
 
 %_pe: %_setup
-	vivado -nolog -nojournal -mode batch -source riscv_pe_project.tcl -tclargs --part $(PYNQ) --bram $(BRAM_SIZE) --cache $(CACHE) --maxi $(MAXI) --project_name $@
+	vivado -nolog -nojournal -mode batch -source riscv_pe_project.tcl -tclargs --part $(PYNQ) --bram $(BRAM_SIZE) --cache $(CACHE) --maxi $(MAXI) --localmem $(LOCALMEM) --versal $(VERSAL) --project_name $@
 	@PE_ID=$$(($$(echo $(PE_LIST) | sed s/$@.*// | wc -w) + 1742)); \
-	tapasco -v import IP/$@/esa.informatik.tu-darmstadt.de_tapasco_$@_1.0.zip as $$PE_ID
+	tapasco -v import IP/$@/esa.informatik.tu-darmstadt.de_tapasco_$@_1.0.zip as $$PE_ID ${TAPASCO_PLATFORM}
 
 %_setup: riscv/%/setup.sh
 	$<

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,21 @@
 SHELL=/bin/bash
 
+#Settings for 7-series, UltraScale(+)
 PYNQ=xc7z020clg400-1
 TAPASCO_PLATFORM=
 VERSAL=false
 
+#Versal V80
 #PYNQ=xcv80-lsva4737-2MHP-e-S
 #TAPASCO_PLATFORM=-p v80
 #VERSAL=true
 
+#BRAM_SIZE sets the size in bytes for the data and instruction BRAMs. The combined size will be 2x BRAM_SIZE.
+#Set BRAM_SIZE to 0 to disable local memory. Note: that does NOT set the core's boot address to external memory.
 BRAM_SIZE?=0x4000
 XLEN?=32
 CACHE?=false
 MAXI?=1
-LOCALMEM?=true
 
 ifndef TAPASCO_HOME
 $(error TAPASCO_HOME is not set, make sure to source setup.sh in TaPaSCo dir)
@@ -35,7 +38,7 @@ list:
 	@echo $(CORE_LIST)
 
 %_pe: %_setup
-	vivado -nolog -nojournal -mode batch -source riscv_pe_project.tcl -tclargs --part $(PYNQ) --bram $(BRAM_SIZE) --cache $(CACHE) --maxi $(MAXI) --localmem $(LOCALMEM) --versal $(VERSAL) --project_name $@
+	vivado -nolog -nojournal -mode batch -source riscv_pe_project.tcl -tclargs --part $(PYNQ) --bram $(BRAM_SIZE) --cache $(CACHE) --maxi $(MAXI) --versal $(VERSAL) --project_name $@
 	@PE_ID=$$(($$(echo $(PE_LIST) | sed s/$@.*// | wc -w) + 1742)); \
 	tapasco -v import IP/$@/esa.informatik.tu-darmstadt.de_tapasco_$@_1.0.zip as $$PE_ID ${TAPASCO_PLATFORM}
 

--- a/common/bus_util.tcl
+++ b/common/bus_util.tcl
@@ -1,0 +1,12 @@
+# Sets all FIFO sizes of an interconnect buffer. Allowed values for dim_ar, dim_aw, dim_b: 0,1,2,4,8,16,32; dim_r, dim_w also allow 64..4096
+# Requires CONFIG.ADVANCED_PROPERTIES to be initialized, e.g. to {}
+# Example: set_bus_buffer_fifos [get_bd_cells axi_interconnect_1] M00_Buffer 4 4 4 4 4
+proc set_bus_buffer_fifos { cell buffer dim_ar dim_aw dim_b dim_r dim_w } {
+  set prop [get_property CONFIG.ADVANCED_PROPERTIES $cell]
+  dict set prop __view__ functional $buffer AR_SIZE $dim_ar
+  dict set prop __view__ functional $buffer AW_SIZE $dim_aw
+  dict set prop __view__ functional $buffer B_SIZE $dim_b
+  dict set prop __view__ functional $buffer R_SIZE $dim_r
+  dict set prop __view__ functional $buffer W_SIZE $dim_w
+  set_property CONFIG.ADVANCED_PROPERTIES $prop $cell
+}

--- a/common/common_addr_segments.tcl
+++ b/common/common_addr_segments.tcl
@@ -9,7 +9,6 @@ set has_two_addr_spaces [procExists get_external_mem_addr_space2]
 # TaPaSCo address segments
 create_bd_addr_seg -range 0x00004000 -offset 0x11000000 [get_bd_addr_spaces AXIGate_0/maxi] [get_bd_addr_segs RVController_0/saxi/reg0] SEG_RVController_0_reg0
 
-set addr_width [get_property CONFIG.ADDR_WIDTH $cpu_dmem]
 if {$addr_width == 32} {
 	create_bd_addr_seg -range 2G -offset 0x80000000 [get_external_mem_addr_space] [get_bd_addr_segs dmaOffset/S_AXI/reg0] SEG_dmaOffset_reg0
 	if {$has_two_addr_spaces == 1} {
@@ -39,8 +38,10 @@ if {$maxi_ports == 2} {
 }
 
 create_bd_addr_seg -range 0x00010000 -offset 0x00000000 [get_bd_addr_spaces S_AXI_CTRL] [get_bd_addr_segs AXIGate_0/saxi/reg0] SEG_AXIGate_0_reg0
-create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces S_AXI_BRAM] [get_bd_addr_segs ps_dmem_ctrl/S_AXI/Mem0] SEG_ps_dmem_ctrl_Mem0
-create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces S_AXI_BRAM] [get_bd_addr_segs ps_imem_ctrl/S_AXI/Mem0] SEG_ps_imem_ctrl_Mem0
+if {$lmem > 0} {
+	create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces S_AXI_BRAM] [get_bd_addr_segs ps_dmem_ctrl/S_AXI/Mem0] SEG_ps_dmem_ctrl_Mem0
+	create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces S_AXI_BRAM] [get_bd_addr_segs ps_imem_ctrl/S_AXI/Mem0] SEG_ps_imem_ctrl_Mem0
+}
 
 
 create_specific_addr_segs

--- a/common/connect_common_interfaces.tcl
+++ b/common/connect_common_interfaces.tcl
@@ -7,8 +7,8 @@ connect_bd_intf_net -intf_net axi_interconnect_0_M00_AXI [get_bd_intf_pins RVCon
 connect_bd_intf_net -intf_net axi_interconnect_1_M00_AXI [get_bd_intf_pins axi_interconnect_1/M00_AXI] [get_bd_intf_pins ps_imem_ctrl/S_AXI]
 connect_bd_intf_net -intf_net axi_interconnect_1_M01_AXI [get_bd_intf_pins axi_interconnect_1/M01_AXI] [get_bd_intf_pins ps_dmem_ctrl/S_AXI]
 
-connect_bd_intf_net -intf_net ps_dmem_ctrl_BRAM_PORTA [get_bd_intf_pins dmem/BRAM_PORTB] [get_bd_intf_pins ps_dmem_ctrl/BRAM_PORTA]
-connect_bd_intf_net -intf_net ps_imem_ctrl_BRAM_PORTA [get_bd_intf_pins imem/BRAM_PORTB] [get_bd_intf_pins ps_imem_ctrl/BRAM_PORTA]
+connect_bd_intf_net -intf_net ps_dmem_ctrl_BRAM_PORTA [get_bd_intf_pins dmem/BRAM_PORTA] [get_bd_intf_pins ps_dmem_ctrl/BRAM_PORTA]
+connect_bd_intf_net -intf_net ps_imem_ctrl_BRAM_PORTA [get_bd_intf_pins imem/BRAM_PORTA] [get_bd_intf_pins ps_imem_ctrl/BRAM_PORTA]
 
 lappend axi_mem_slaves [get_bd_intf_pins dmaOffset/S_AXI]
 
@@ -23,20 +23,22 @@ if {[info exists axi_io_port]} {
 	lappend axi_mem_slaves [get_bd_intf_pins axi_interconnect_0/S01_AXI]
 }
 
-if {[info exists dbram]} {
-	connect_bd_intf_net $dbram [get_bd_intf_pins dmem/BRAM_PORTA]
-} {
-	lappend axi_mem_slaves [get_bd_intf_pins rv_dmem_ctrl/S_AXI]
-	connect_bd_intf_net -intf_net rv_dmem_ctrl_BRAM_PORTA [get_bd_intf_pins dmem/BRAM_PORTA] [get_bd_intf_pins rv_dmem_ctrl/bram]
-}
-if {[info exists ibram]} {
-	connect_bd_intf_net $ibram [get_bd_intf_pins imem/BRAM_PORTA]
-} elseif {[info exists iaxi]} {
-	connect_bd_intf_net [get_bd_intf_pins imem/BRAM_PORTA] [get_bd_intf_pins rv_imem_ctrl/bram]
-	connect_bd_intf_net [get_bd_intf_pins rv_imem_ctrl/S_AXI] $iaxi
-} {
-	connect_bd_intf_net [get_bd_intf_pins imem/BRAM_PORTA] [get_bd_intf_pins rv_imem_ctrl/bram]
-	lappend axi_mem_slaves [get_bd_intf_pins rv_imem_ctrl/S_AXI]
+if {$core_localmem} {
+	if {[info exists dbram]} {
+		connect_bd_intf_net $dbram [get_bd_intf_pins dmem/BRAM_PORTB]
+	} {
+		lappend axi_mem_slaves [get_bd_intf_pins rv_dmem_ctrl/S_AXI]
+		connect_bd_intf_net -intf_net rv_dmem_ctrl_BRAM_PORTA [get_bd_intf_pins dmem/BRAM_PORTB] [get_bd_intf_pins rv_dmem_ctrl/bram]
+	}
+	if {[info exists ibram]} {
+		connect_bd_intf_net $ibram [get_bd_intf_pins imem/BRAM_PORTB]
+	} elseif {[info exists iaxi]} {
+		connect_bd_intf_net [get_bd_intf_pins imem/BRAM_PORTB] [get_bd_intf_pins rv_imem_ctrl/bram]
+		connect_bd_intf_net [get_bd_intf_pins rv_imem_ctrl/S_AXI] $iaxi
+	} {
+		connect_bd_intf_net [get_bd_intf_pins imem/BRAM_PORTB] [get_bd_intf_pins rv_imem_ctrl/bram]
+		lappend axi_mem_slaves [get_bd_intf_pins rv_imem_ctrl/S_AXI]
+	}
 }
 
 # configure and connect axi_mem_intercon_1
@@ -58,8 +60,12 @@ if {[info exists axi_mem_port]} {
 } {
 	set cpu_dmem [get_bd_intf_pins -of_objects [get_bd_intf_nets -of_objects [get_bd_intf_pins axi_mem_intercon_1/S00_AXI]] -filter {MODE == Master}]
 }
-set data_width [get_property CONFIG.DATA_WIDTH $cpu_dmem]
-set addr_width [get_property CONFIG.ADDR_WIDTH $cpu_dmem]
+if {![info exists data_width]} {
+	set data_width {32}
+}
+if {![info exists addr_width]} {
+	set addr_width {32}
+}
 puts "Configure data path to ${addr_width}-bit address width and ${data_width}-bit data width."
 set_property CONFIG.BYTES_PER_WORD [expr $data_width / 8] [get_bd_cells dmaOffset]
 set_property CONFIG.DATA_WIDTH $data_width [get_bd_intf_ports M_AXI]
@@ -71,8 +77,10 @@ if {$maxi_ports == 2} {
 	set_property CONFIG.ADDRESS_WIDTH $addr_width [get_bd_cells dmaOffset2]
 	set_property CONFIG.ADDR_WIDTH $addr_width [get_bd_intf_ports M_AXI2]
 }
-set_property CONFIG.BYTES_PER_WORD [expr $data_width / 8] [get_bd_cells rv_dmem_ctrl]
-set_property CONFIG.BYTES_PER_WORD [expr $data_width / 8] [get_bd_cells rv_imem_ctrl]
+if {$core_localmem} {
+	set_property CONFIG.BYTES_PER_WORD [expr $data_width / 8] [get_bd_cells rv_dmem_ctrl]
+	set_property CONFIG.BYTES_PER_WORD [expr $data_width / 8] [get_bd_cells rv_imem_ctrl]
+}
 # keep second BRAM port in sync, otherwise problems with larger sizes
 set_property CONFIG.DATA_WIDTH $data_width [get_bd_cells ps_dmem_ctrl]
 set_property CONFIG.DATA_WIDTH $data_width [get_bd_cells ps_imem_ctrl]

--- a/common/connect_common_interfaces.tcl
+++ b/common/connect_common_interfaces.tcl
@@ -1,14 +1,8 @@
 # Connections between controller, TaPaSCo, local memory, etc.
 connect_bd_intf_net -intf_net AXIGate_0_maxi [get_bd_intf_pins AXIGate_0/maxi] [get_bd_intf_pins axi_interconnect_0/S00_AXI]
 connect_bd_intf_net [get_bd_intf_ports M_AXI] [get_bd_intf_pins dmaOffset/M_AXI]
-connect_bd_intf_net -intf_net S_AXI_BRAM_1 [get_bd_intf_ports S_AXI_BRAM] [get_bd_intf_pins axi_interconnect_1/S00_AXI]
 connect_bd_intf_net -intf_net S_AXI_CTRL_1 [get_bd_intf_ports S_AXI_CTRL] [get_bd_intf_pins AXIGate_0/saxi]
 connect_bd_intf_net -intf_net axi_interconnect_0_M00_AXI [get_bd_intf_pins RVController_0/saxi] [get_bd_intf_pins axi_interconnect_0/M00_AXI]
-connect_bd_intf_net -intf_net axi_interconnect_1_M00_AXI [get_bd_intf_pins axi_interconnect_1/M00_AXI] [get_bd_intf_pins ps_imem_ctrl/S_AXI]
-connect_bd_intf_net -intf_net axi_interconnect_1_M01_AXI [get_bd_intf_pins axi_interconnect_1/M01_AXI] [get_bd_intf_pins ps_dmem_ctrl/S_AXI]
-
-connect_bd_intf_net -intf_net ps_dmem_ctrl_BRAM_PORTA [get_bd_intf_pins dmem/BRAM_PORTA] [get_bd_intf_pins ps_dmem_ctrl/BRAM_PORTA]
-connect_bd_intf_net -intf_net ps_imem_ctrl_BRAM_PORTA [get_bd_intf_pins imem/BRAM_PORTA] [get_bd_intf_pins ps_imem_ctrl/BRAM_PORTA]
 
 lappend axi_mem_slaves [get_bd_intf_pins dmaOffset/S_AXI]
 
@@ -23,20 +17,25 @@ if {[info exists axi_io_port]} {
 	lappend axi_mem_slaves [get_bd_intf_pins axi_interconnect_0/S01_AXI]
 }
 
-if {$core_localmem} {
+if {$lmem > 0} {
+	connect_bd_intf_net -intf_net S_AXI_BRAM_1 [get_bd_intf_ports S_AXI_BRAM] [get_bd_intf_pins axi_interconnect_1/S00_AXI]
+	connect_bd_intf_net -intf_net axi_interconnect_1_M00_AXI [get_bd_intf_pins axi_interconnect_1/M00_AXI] [get_bd_intf_pins ps_imem_ctrl/S_AXI]
+	connect_bd_intf_net -intf_net axi_interconnect_1_M01_AXI [get_bd_intf_pins axi_interconnect_1/M01_AXI] [get_bd_intf_pins ps_dmem_ctrl/S_AXI]
+	connect_bd_intf_net -intf_net ps_dmem_ctrl_BRAM_PORTA [get_bd_intf_pins dmem/BRAM_PORTB] [get_bd_intf_pins ps_dmem_ctrl/BRAM_PORTA]
+	connect_bd_intf_net -intf_net ps_imem_ctrl_BRAM_PORTA [get_bd_intf_pins imem/BRAM_PORTB] [get_bd_intf_pins ps_imem_ctrl/BRAM_PORTA]
 	if {[info exists dbram]} {
-		connect_bd_intf_net $dbram [get_bd_intf_pins dmem/BRAM_PORTB]
+		connect_bd_intf_net $dbram [get_bd_intf_pins dmem/BRAM_PORTA]
 	} {
 		lappend axi_mem_slaves [get_bd_intf_pins rv_dmem_ctrl/S_AXI]
-		connect_bd_intf_net -intf_net rv_dmem_ctrl_BRAM_PORTA [get_bd_intf_pins dmem/BRAM_PORTB] [get_bd_intf_pins rv_dmem_ctrl/bram]
+		connect_bd_intf_net -intf_net rv_dmem_ctrl_BRAM_PORTA [get_bd_intf_pins dmem/BRAM_PORTA] [get_bd_intf_pins rv_dmem_ctrl/bram]
 	}
 	if {[info exists ibram]} {
-		connect_bd_intf_net $ibram [get_bd_intf_pins imem/BRAM_PORTB]
+		connect_bd_intf_net $ibram [get_bd_intf_pins imem/BRAM_PORTA]
 	} elseif {[info exists iaxi]} {
-		connect_bd_intf_net [get_bd_intf_pins imem/BRAM_PORTB] [get_bd_intf_pins rv_imem_ctrl/bram]
+		connect_bd_intf_net [get_bd_intf_pins imem/BRAM_PORTA] [get_bd_intf_pins rv_imem_ctrl/bram]
 		connect_bd_intf_net [get_bd_intf_pins rv_imem_ctrl/S_AXI] $iaxi
 	} {
-		connect_bd_intf_net [get_bd_intf_pins imem/BRAM_PORTB] [get_bd_intf_pins rv_imem_ctrl/bram]
+		connect_bd_intf_net [get_bd_intf_pins imem/BRAM_PORTA] [get_bd_intf_pins rv_imem_ctrl/bram]
 		lappend axi_mem_slaves [get_bd_intf_pins rv_imem_ctrl/S_AXI]
 	}
 }
@@ -50,6 +49,7 @@ if {[llength $axi_mem_slaves] == 1} {
 	set_property CONFIG.NUM_MI [llength $axi_mem_slaves] [get_bd_cells axi_mem_intercon_1]
 	set ic_master_ports [get_bd_intf_pins -filter {VLNV == "xilinx.com:interface:aximm_rtl:1.0" && MODE == "Master"} -of_objects [get_bd_cells axi_mem_intercon_1]]
 	for {set i 0} {$i < [llength $axi_mem_slaves]} {incr i} {
+		set_bus_buffer_fifos [get_bd_cells axi_mem_intercon_1] [format "M%02d_Buffer" $i] 4 4 4 4 4
 		connect_bd_intf_net [lindex $axi_mem_slaves $i] [lindex $ic_master_ports $i]
 	}
 }
@@ -60,12 +60,18 @@ if {[info exists axi_mem_port]} {
 } {
 	set cpu_dmem [get_bd_intf_pins -of_objects [get_bd_intf_nets -of_objects [get_bd_intf_pins axi_mem_intercon_1/S00_AXI]] -filter {MODE == Master}]
 }
-if {![info exists data_width]} {
-	set data_width {32}
+if {[get_property CONFIG.DATA_WIDTH $cpu_dmem] > 0} { # does not work with Smartconnect before bd_validate
+	set data_width [get_property CONFIG.DATA_WIDTH $cpu_dmem]
 }
-if {![info exists addr_width]} {
-	set addr_width {32}
+if {[get_property CONFIG.ADDR_WIDTH $cpu_dmem] > 0} { # does not work with Smartconnect before bd_validate
+	set addr_width [get_property CONFIG.ADDR_WIDTH $cpu_dmem]
 }
+
+if {![info exists data_width] || ![info exists addr_width]} {
+	puts stderr "Could not retrieve the core's memory bus data/addr widths"
+	exit 1
+}
+
 puts "Configure data path to ${addr_width}-bit address width and ${data_width}-bit data width."
 set_property CONFIG.BYTES_PER_WORD [expr $data_width / 8] [get_bd_cells dmaOffset]
 set_property CONFIG.DATA_WIDTH $data_width [get_bd_intf_ports M_AXI]
@@ -77,10 +83,10 @@ if {$maxi_ports == 2} {
 	set_property CONFIG.ADDRESS_WIDTH $addr_width [get_bd_cells dmaOffset2]
 	set_property CONFIG.ADDR_WIDTH $addr_width [get_bd_intf_ports M_AXI2]
 }
-if {$core_localmem} {
+if {$lmem > 0} {
 	set_property CONFIG.BYTES_PER_WORD [expr $data_width / 8] [get_bd_cells rv_dmem_ctrl]
 	set_property CONFIG.BYTES_PER_WORD [expr $data_width / 8] [get_bd_cells rv_imem_ctrl]
+	# keep second BRAM port in sync, otherwise problems with larger sizes
+	set_property CONFIG.DATA_WIDTH $data_width [get_bd_cells ps_dmem_ctrl]
+	set_property CONFIG.DATA_WIDTH $data_width [get_bd_cells ps_imem_ctrl]
 }
-# keep second BRAM port in sync, otherwise problems with larger sizes
-set_property CONFIG.DATA_WIDTH $data_width [get_bd_cells ps_dmem_ctrl]
-set_property CONFIG.DATA_WIDTH $data_width [get_bd_cells ps_imem_ctrl]

--- a/common/connect_common_ports.tcl
+++ b/common/connect_common_ports.tcl
@@ -1,9 +1,15 @@
 # Connections for clocks, local memory and everything that's independent from the processor
 connect_bd_net -net ARESET_N_1 [get_bd_ports ARESET_N] [get_bd_pins rst_CLK_100M/ext_reset_in]
-connect_bd_net -net CLK_1 [get_bd_ports CLK] [get_bd_pins AXIGate_0/CLK] [get_bd_pins RVController_0/CLK] [get_bd_pins axi_interconnect_0/ACLK] [get_bd_pins axi_interconnect_0/M00_ACLK] [get_bd_pins axi_interconnect_0/S00_ACLK] [get_bd_pins axi_interconnect_0/S01_ACLK] [get_bd_pins axi_interconnect_1/ACLK] [get_bd_pins axi_interconnect_1/M00_ACLK] [get_bd_pins axi_interconnect_1/M01_ACLK] [get_bd_pins axi_interconnect_1/S00_ACLK] [get_bd_pins axi_mem_intercon_1/ACLK] [get_bd_pins axi_mem_intercon_1/M0*_ACLK] [get_bd_pins axi_mem_intercon_1/S0*_ACLK] [get_bd_pins dmaOffset/CLK] $cpu_clk [get_bd_pins ps_dmem_ctrl/s_axi_aclk] [get_bd_pins ps_imem_ctrl/s_axi_aclk] [get_bd_pins rst_CLK_100M/slowest_sync_clk] [get_bd_pins rv_dmem_ctrl/CLK] [get_bd_pins rv_imem_ctrl/CLK]
+connect_bd_net -net CLK_1 [get_bd_ports CLK] [get_bd_pins AXIGate_0/CLK] [get_bd_pins RVController_0/CLK] [get_bd_pins axi_interconnect_0/ACLK] [get_bd_pins axi_mem_intercon_1/ACLK] [get_bd_pins dmaOffset/CLK] $cpu_clk [get_bd_pins rst_CLK_100M/slowest_sync_clk]
 connect_bd_net -net RVController_0_tapasco_intr [get_bd_ports interrupt] [get_bd_pins RVController_0/tapasco_intr]
-connect_bd_net -net rst_CLK_100M_interconnect_aresetn [get_bd_pins axi_interconnect_0/ARESETN] [get_bd_pins axi_interconnect_1/ARESETN] [get_bd_pins axi_mem_intercon_1/ARESETN] [get_bd_pins rst_CLK_100M/interconnect_aresetn]
-connect_bd_net -net rst_CLK_100M_peripheral_aresetn [get_bd_pins AXIGate_0/RST_N] [get_bd_pins RVController_0/RST_N] [get_bd_pins axi_interconnect_0/M00_ARESETN] [get_bd_pins axi_interconnect_0/S00_ARESETN] [get_bd_pins axi_interconnect_0/S01_ARESETN] [get_bd_pins axi_interconnect_1/M00_ARESETN] [get_bd_pins axi_interconnect_1/M01_ARESETN] [get_bd_pins axi_interconnect_1/S00_ARESETN] [get_bd_pins axi_mem_intercon_1/M00_ARESETN] [get_bd_pins axi_mem_intercon_1/M0*_ARESETN] [get_bd_pins axi_mem_intercon_1/S0*_ARESETN] [get_bd_pins dmaOffset/RST_N] [get_bd_pins ps_dmem_ctrl/s_axi_aresetn] [get_bd_pins ps_imem_ctrl/s_axi_aresetn] [get_bd_pins rst_CLK_100M/peripheral_aresetn] [get_bd_pins rv_dmem_ctrl/RST_N] [get_bd_pins rv_imem_ctrl/RST_N]
+connect_bd_net -net rst_CLK_100M_interconnect_aresetn [get_bd_pins axi_interconnect_0/ARESETN] [get_bd_pins axi_mem_intercon_1/ARESETN] [get_bd_pins rst_CLK_100M/interconnect_aresetn]
+connect_bd_net -net rst_CLK_100M_peripheral_aresetn [get_bd_pins AXIGate_0/RST_N] [get_bd_pins RVController_0/RST_N] [get_bd_pins dmaOffset/RST_N] [get_bd_pins rst_CLK_100M/peripheral_aresetn]
+
+if {$lmem > 0} {
+	connect_bd_net -net CLK_1 [get_bd_pins axi_interconnect_1/ACLK] [get_bd_pins ps_dmem_ctrl/s_axi_aclk] [get_bd_pins ps_imem_ctrl/s_axi_aclk] [get_bd_pins rv_dmem_ctrl/CLK] [get_bd_pins rv_imem_ctrl/CLK]
+	connect_bd_net -net rst_CLK_100M_interconnect_aresetn [get_bd_pins axi_interconnect_1/ARESETN]
+	connect_bd_net -net rst_CLK_100M_peripheral_aresetn [get_bd_pins ps_dmem_ctrl/s_axi_aresetn] [get_bd_pins ps_imem_ctrl/s_axi_aresetn] [get_bd_pins rv_dmem_ctrl/RST_N] [get_bd_pins rv_imem_ctrl/RST_N]
+}
 
 if {$maxi_ports == 2} {
 	connect_bd_net -net CLK_1 [get_bd_pins dmaOffset2/CLK]

--- a/common/package.tcl
+++ b/common/package.tcl
@@ -26,8 +26,10 @@ ipx::remove_bus_parameter PHASE [ipx::get_bus_interfaces CLK -of_objects $core]
 set_property name ARESET_N [ipx::get_bus_interfaces RST.ARESET_N -of_objects $core]
 
 # Memory
-ipx::remove_address_block Mem1 [ipx::get_memory_maps S_AXI_BRAM -of_objects $core]
-set_property range [expr {$lmem * 2}] [ipx::get_address_blocks Mem0 -of_objects [ipx::get_memory_maps S_AXI_BRAM -of_objects $core]]
+if {$lmem > 0} {
+	ipx::remove_address_block Mem1 [ipx::get_memory_maps S_AXI_BRAM -of_objects $core]
+	set_property range [expr {$lmem * 2}] [ipx::get_address_blocks Mem0 -of_objects [ipx::get_memory_maps S_AXI_BRAM -of_objects $core]]
+}
 
 # Finish up
 set_property core_revision 1 $core

--- a/common/package.tcl
+++ b/common/package.tcl
@@ -1,7 +1,7 @@
 ipx::package_project -root_dir IP/$project_name -module $project_name -generated_files -import_files -force
 
 # Set platform compatibility
-set_property supported_families {virtex7 Beta qvirtex7 Beta kintex7 Beta kintex7l Beta qkintex7 Beta qkintex7l Beta artix7 Beta artix7l Beta aartix7 Beta qartix7 Beta zynq Beta qzynq Beta azynq Beta spartan7 Beta aspartan7 Beta virtexu Beta virtexuplus Beta virtexuplusHBM Beta kintexuplus Beta zynquplus Beta kintexu Beta} [ipx::current_core]
+set_property supported_families {virtex7 Beta qvirtex7 Beta kintex7 Beta kintex7l Beta qkintex7 Beta qkintex7l Beta artix7 Beta artix7l Beta aartix7 Beta qartix7 Beta zynq Beta qzynq Beta azynq Beta spartan7 Beta aspartan7 Beta virtexu Beta virtexuplus Beta virtexuplusHBM Beta kintexuplus Beta zynquplus Beta kintexu Beta versal Beta} [ipx::current_core]
 
 set core [ipx::current_core]
 

--- a/common/parse_args.tcl
+++ b/common/parse_args.tcl
@@ -34,7 +34,9 @@ if { $::argc > 0 } {
       "--part"         { incr i; set part [lindex $::argv $i] }
       "--bram"         { incr i; set lmem [lindex $::argv $i] }
       "--maxi"         { incr i; set maxi_ports [lindex $::argv $i] }
-      "--cache"		   { incr i; set cache [lindex $::argv $i] }
+      "--cache"        { incr i; set cache [lindex $::argv $i] }
+      "--localmem"     { incr i; set core_localmem [lindex $::argv $i] }
+      "--versal"       { incr i; set versal_embmem [lindex $::argv $i] }
       "--project_name" { incr i; set project_name [lindex $::argv $i] }
       "--help"         { help }
       default {

--- a/common/parse_args.tcl
+++ b/common/parse_args.tcl
@@ -35,7 +35,6 @@ if { $::argc > 0 } {
       "--bram"         { incr i; set lmem [lindex $::argv $i] }
       "--maxi"         { incr i; set maxi_ports [lindex $::argv $i] }
       "--cache"        { incr i; set cache [lindex $::argv $i] }
-      "--localmem"     { incr i; set core_localmem [lindex $::argv $i] }
       "--versal"       { incr i; set versal_embmem [lindex $::argv $i] }
       "--project_name" { incr i; set project_name [lindex $::argv $i] }
       "--help"         { help }

--- a/common/place_local_memory.tcl
+++ b/common/place_local_memory.tcl
@@ -1,76 +1,81 @@
-# Create instance: axi_interconnect_1, and set properties (minimize area)
-set axi_interconnect_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 axi_interconnect_1 ]
-set_property -dict [ list \
-  CONFIG.NUM_MI {2} \
-  CONFIG.NUM_SI {1} \
-] $axi_interconnect_1
-
 # Create instance: axi_mem_intercon_1, and set properties (maximize performance)
 set axi_mem_intercon_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 axi_mem_intercon_1 ]
 # reduce NUM_MI later for direct bram connection
 set_property -dict [ list \
   CONFIG.NUM_MI {3} \
   CONFIG.NUM_SI {1} \
+  CONFIG.ADVANCED_PROPERTIES {} \
 ] $axi_mem_intercon_1
-
-# Create instance: dmem, and set properties
-if {$versal_embmem} {
-  set dmem [ create_bd_cell -type ip -vlnv xilinx.com:ip:emb_mem_gen:1.0 dmem ]
-  if {$core_localmem} {
-    set_property -dict [ list \
-      CONFIG.MEMORY_TYPE {True_Dual_Port_RAM} \
-    ] $dmem
-  }
-} {
-  set dmem [ create_bd_cell -type ip -vlnv xilinx.com:ip:blk_mem_gen:8.4 dmem ]
-  set_property -dict [ list \
-    CONFIG.Assume_Synchronous_Clk {true} \
-    CONFIG.EN_SAFETY_CKT {false} \
-    CONFIG.Enable_B {Use_ENB_Pin} \
-    CONFIG.Memory_Type {True_Dual_Port_RAM} \
-    CONFIG.Port_B_Clock {100} \
-    CONFIG.Port_B_Enable_Rate {100} \
-    CONFIG.Port_B_Write_Rate {50} \
-    CONFIG.Use_RSTB_Pin {true} \
-  ] $dmem
-}
-
-# Create instance: imem, and set properties
-if {$versal_embmem} {
-  set imem [ create_bd_cell -type ip -vlnv xilinx.com:ip:emb_mem_gen:1.0 imem ]
-  set_property -dict [ list \
-    CONFIG.MEMORY_TYPE {True_Dual_Port_RAM} \
-  ] $imem
-} {
-  set imem [ create_bd_cell -type ip -vlnv xilinx.com:ip:blk_mem_gen:8.4 imem ]
-  set_property -dict [ list \
-    CONFIG.Assume_Synchronous_Clk {true} \
-    CONFIG.EN_SAFETY_CKT {false} \
-    CONFIG.Enable_B {Use_ENB_Pin} \
-    CONFIG.Memory_Type {True_Dual_Port_RAM} \
-    CONFIG.Port_B_Clock {100} \
-    CONFIG.Port_B_Enable_Rate {100} \
-    CONFIG.Port_B_Write_Rate {50} \
-    CONFIG.Use_RSTB_Pin {true} \
-  ] $imem
-}
- 
-# Create instance: ps_dmem_ctrl, and set properties
-set ps_dmem_ctrl [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_bram_ctrl ps_dmem_ctrl ]
-set_property -dict [ list \
-  CONFIG.SINGLE_PORT_BRAM {1} \
-] $ps_dmem_ctrl
-
-# Create instance: ps_imem_ctrl, and set properties
-set ps_imem_ctrl [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_bram_ctrl ps_imem_ctrl ]
-set_property -dict [ list \
-  CONFIG.SINGLE_PORT_BRAM {1} \
-] $ps_imem_ctrl
+set_bus_buffer_fifos [get_bd_cells axi_mem_intercon_1] S00_Buffer 4 4 4 4 4
+#M00..M02_Buffer FIFOs set by connect_common_interfaces.tcl
 
 # Create instance: rst_CLK_100M, and set properties
 set rst_CLK_100M [ create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset:5.0 rst_CLK_100M ]
 
-if {$core_localmem} {
+if {$lmem > 0} {
+  # Create instance: axi_interconnect_1, and set properties (minimize area)
+  set axi_interconnect_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 axi_interconnect_1 ]
+  set_property -dict [ list \
+    CONFIG.NUM_MI {2} \
+    CONFIG.NUM_SI {1} \
+    CONFIG.ADVANCED_PROPERTIES {} \
+  ] $axi_interconnect_1
+  set_bus_buffer_fifos [get_bd_cells axi_interconnect_1] M00_Buffer 4 4 4 4 4
+  set_bus_buffer_fifos [get_bd_cells axi_interconnect_1] M01_Buffer 4 4 4 4 4
+  set_bus_buffer_fifos [get_bd_cells axi_interconnect_1] S00_Buffer 4 4 4 4 4
+
+  # Create instance: dmem, and set properties
+  if {$versal_embmem} {
+    set dmem [ create_bd_cell -type ip -vlnv xilinx.com:ip:emb_mem_gen:1.0 dmem ]
+    set_property -dict [ list \
+      CONFIG.MEMORY_TYPE {True_Dual_Port_RAM} \
+    ] $dmem
+  } {
+    set dmem [ create_bd_cell -type ip -vlnv xilinx.com:ip:blk_mem_gen:8.4 dmem ]
+    set_property -dict [ list \
+      CONFIG.Assume_Synchronous_Clk {true} \
+      CONFIG.EN_SAFETY_CKT {false} \
+      CONFIG.Enable_B {Use_ENB_Pin} \
+      CONFIG.Memory_Type {True_Dual_Port_RAM} \
+      CONFIG.Port_B_Clock {100} \
+      CONFIG.Port_B_Enable_Rate {100} \
+      CONFIG.Port_B_Write_Rate {50} \
+      CONFIG.Use_RSTB_Pin {true} \
+    ] $dmem
+  }
+
+  # Create instance: imem, and set properties
+  if {$versal_embmem} {
+    set imem [ create_bd_cell -type ip -vlnv xilinx.com:ip:emb_mem_gen:1.0 imem ]
+    set_property -dict [ list \
+      CONFIG.MEMORY_TYPE {True_Dual_Port_RAM} \
+    ] $imem
+  } {
+    set imem [ create_bd_cell -type ip -vlnv xilinx.com:ip:blk_mem_gen:8.4 imem ]
+    set_property -dict [ list \
+      CONFIG.Assume_Synchronous_Clk {true} \
+      CONFIG.EN_SAFETY_CKT {false} \
+      CONFIG.Enable_B {Use_ENB_Pin} \
+      CONFIG.Memory_Type {True_Dual_Port_RAM} \
+      CONFIG.Port_B_Clock {100} \
+      CONFIG.Port_B_Enable_Rate {100} \
+      CONFIG.Port_B_Write_Rate {50} \
+      CONFIG.Use_RSTB_Pin {true} \
+    ] $imem
+  }
+ 
+  # Create instance: ps_dmem_ctrl, and set properties
+  set ps_dmem_ctrl [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_bram_ctrl ps_dmem_ctrl ]
+  set_property -dict [ list \
+    CONFIG.SINGLE_PORT_BRAM {1} \
+  ] $ps_dmem_ctrl
+
+  # Create instance: ps_imem_ctrl, and set properties
+  set ps_imem_ctrl [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_bram_ctrl ps_imem_ctrl ]
+  set_property -dict [ list \
+    CONFIG.SINGLE_PORT_BRAM {1} \
+  ] $ps_imem_ctrl
+
   # Create instance: rv_dmem_ctrl, and set properties
   set rv_dmem_ctrl [ create_bd_cell -type ip -vlnv esa.cs.tu-darmstadt.de:axi:axi_ctrl rv_dmem_ctrl ]
   set_property -dict [ list \

--- a/common/place_local_memory.tcl
+++ b/common/place_local_memory.tcl
@@ -1,68 +1,86 @@
 # Create instance: axi_interconnect_1, and set properties (minimize area)
-  set axi_interconnect_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_interconnect:2.1 axi_interconnect_1 ]
-  set_property CONFIG.STRATEGY {1} $axi_interconnect_1
+set axi_interconnect_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 axi_interconnect_1 ]
+set_property -dict [ list \
+  CONFIG.NUM_MI {2} \
+  CONFIG.NUM_SI {1} \
+] $axi_interconnect_1
 
-  # Create instance: axi_mem_intercon_1, and set properties (maximize performance)
-  set axi_mem_intercon_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_interconnect:2.1 axi_mem_intercon_1 ]
-  # reduce NUM_MI later for direct bram connection
-  set_property -dict [ list \
-   CONFIG.NUM_MI {3} \
-   CONFIG.NUM_SI {1} \
-   CONFIG.STRATEGY {0} \
-   CONFIG.ENABLE_ADVANCED_OPTIONS {1} \
-   CONFIG.S00_HAS_DATA_FIFO {0} \
- ] $axi_mem_intercon_1
+# Create instance: axi_mem_intercon_1, and set properties (maximize performance)
+set axi_mem_intercon_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 axi_mem_intercon_1 ]
+# reduce NUM_MI later for direct bram connection
+set_property -dict [ list \
+  CONFIG.NUM_MI {3} \
+  CONFIG.NUM_SI {1} \
+] $axi_mem_intercon_1
 
-  # Create instance: dmem, and set properties
+# Create instance: dmem, and set properties
+if {$versal_embmem} {
+  set dmem [ create_bd_cell -type ip -vlnv xilinx.com:ip:emb_mem_gen:1.0 dmem ]
+  if {$core_localmem} {
+    set_property -dict [ list \
+      CONFIG.MEMORY_TYPE {True_Dual_Port_RAM} \
+    ] $dmem
+  }
+} {
   set dmem [ create_bd_cell -type ip -vlnv xilinx.com:ip:blk_mem_gen:8.4 dmem ]
   set_property -dict [ list \
-   CONFIG.Assume_Synchronous_Clk {true} \
-   CONFIG.EN_SAFETY_CKT {false} \
-   CONFIG.Enable_B {Use_ENB_Pin} \
-   CONFIG.Memory_Type {True_Dual_Port_RAM} \
-   CONFIG.Port_B_Clock {100} \
-   CONFIG.Port_B_Enable_Rate {100} \
-   CONFIG.Port_B_Write_Rate {50} \
-   CONFIG.Use_RSTB_Pin {true} \
- ] $dmem
+    CONFIG.Assume_Synchronous_Clk {true} \
+    CONFIG.EN_SAFETY_CKT {false} \
+    CONFIG.Enable_B {Use_ENB_Pin} \
+    CONFIG.Memory_Type {True_Dual_Port_RAM} \
+    CONFIG.Port_B_Clock {100} \
+    CONFIG.Port_B_Enable_Rate {100} \
+    CONFIG.Port_B_Write_Rate {50} \
+    CONFIG.Use_RSTB_Pin {true} \
+  ] $dmem
+}
 
-  # Create instance: imem, and set properties
+# Create instance: imem, and set properties
+if {$versal_embmem} {
+  set imem [ create_bd_cell -type ip -vlnv xilinx.com:ip:emb_mem_gen:1.0 imem ]
+  set_property -dict [ list \
+    CONFIG.MEMORY_TYPE {True_Dual_Port_RAM} \
+  ] $imem
+} {
   set imem [ create_bd_cell -type ip -vlnv xilinx.com:ip:blk_mem_gen:8.4 imem ]
   set_property -dict [ list \
-   CONFIG.Assume_Synchronous_Clk {true} \
-   CONFIG.EN_SAFETY_CKT {false} \
-   CONFIG.Enable_B {Use_ENB_Pin} \
-   CONFIG.Memory_Type {True_Dual_Port_RAM} \
-   CONFIG.Port_B_Clock {100} \
-   CONFIG.Port_B_Enable_Rate {100} \
-   CONFIG.Port_B_Write_Rate {50} \
-   CONFIG.Use_RSTB_Pin {true} \
- ] $imem
+    CONFIG.Assume_Synchronous_Clk {true} \
+    CONFIG.EN_SAFETY_CKT {false} \
+    CONFIG.Enable_B {Use_ENB_Pin} \
+    CONFIG.Memory_Type {True_Dual_Port_RAM} \
+    CONFIG.Port_B_Clock {100} \
+    CONFIG.Port_B_Enable_Rate {100} \
+    CONFIG.Port_B_Write_Rate {50} \
+    CONFIG.Use_RSTB_Pin {true} \
+  ] $imem
+}
  
- # Create instance: ps_dmem_ctrl, and set properties
-  set ps_dmem_ctrl [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_bram_ctrl ps_dmem_ctrl ]
-  set_property -dict [ list \
-   CONFIG.SINGLE_PORT_BRAM {1} \
- ] $ps_dmem_ctrl
+# Create instance: ps_dmem_ctrl, and set properties
+set ps_dmem_ctrl [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_bram_ctrl ps_dmem_ctrl ]
+set_property -dict [ list \
+  CONFIG.SINGLE_PORT_BRAM {1} \
+] $ps_dmem_ctrl
 
-  # Create instance: ps_imem_ctrl, and set properties
-  set ps_imem_ctrl [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_bram_ctrl ps_imem_ctrl ]
-  set_property -dict [ list \
-   CONFIG.SINGLE_PORT_BRAM {1} \
- ] $ps_imem_ctrl
+# Create instance: ps_imem_ctrl, and set properties
+set ps_imem_ctrl [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_bram_ctrl ps_imem_ctrl ]
+set_property -dict [ list \
+  CONFIG.SINGLE_PORT_BRAM {1} \
+] $ps_imem_ctrl
 
-  # Create instance: rst_CLK_100M, and set properties
-  set rst_CLK_100M [ create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset:5.0 rst_CLK_100M ]
+# Create instance: rst_CLK_100M, and set properties
+set rst_CLK_100M [ create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset:5.0 rst_CLK_100M ]
 
+if {$core_localmem} {
   # Create instance: rv_dmem_ctrl, and set properties
   set rv_dmem_ctrl [ create_bd_cell -type ip -vlnv esa.cs.tu-darmstadt.de:axi:axi_ctrl rv_dmem_ctrl ]
   set_property -dict [ list \
-   CONFIG.MEM_SIZE [expr $lmem] \
- ] $rv_dmem_ctrl
+    CONFIG.MEM_SIZE [expr $lmem] \
+  ] $rv_dmem_ctrl
 
   # Create instance: rv_imem_ctrl, and set properties
   set rv_imem_ctrl [ create_bd_cell -type ip -vlnv esa.cs.tu-darmstadt.de:axi:axi_ctrl rv_imem_ctrl ]
   set_property -dict [ list \
-   CONFIG.MEM_SIZE [expr $lmem] \
-   CONFIG.READ_ONLY {1} \
- ] $rv_imem_ctrl
+    CONFIG.MEM_SIZE [expr $lmem] \
+    CONFIG.READ_ONLY {1} \
+  ] $rv_imem_ctrl
+}

--- a/common/place_tapasco_control.tcl
+++ b/common/place_tapasco_control.tcl
@@ -15,6 +15,7 @@ if {$maxi_ports == 2} {
     ] $M_AXI2
 }
 
+if {$lmem > 0} {
   set S_AXI_BRAM [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 S_AXI_BRAM ]
   set_property -dict [ list \
    CONFIG.ADDR_WIDTH [expr log10($lmem*2)/log10(2)] \
@@ -45,6 +46,7 @@ if {$maxi_ports == 2} {
    CONFIG.WUSER_BITS_PER_BYTE {0} \
    CONFIG.WUSER_WIDTH {0} \
    ] $S_AXI_BRAM
+}
   set S_AXI_CTRL [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 S_AXI_CTRL ]
   set_property -dict [ list \
    CONFIG.ADDR_WIDTH {16} \
@@ -82,9 +84,11 @@ if {$maxi_ports == 2} {
    CONFIG.POLARITY {ACTIVE_LOW} \
  ] $ARESET_N
   set CLK [ create_bd_port -dir I -type clk CLK ]
-  set_property -dict [ list \
-   CONFIG.ASSOCIATED_BUSIF {S_AXI_BRAM:S_AXI_CTRL:M_AXI} \
- ] $CLK
+  if {$lmem > 0} {
+    set_property CONFIG.ASSOCIATED_BUSIF {S_AXI_BRAM:S_AXI_CTRL:M_AXI} $CLK
+  } {
+    set_property CONFIG.ASSOCIATED_BUSIF {S_AXI_CTRL:M_AXI} $CLK
+  }
   set interrupt [ create_bd_port -dir O -type intr interrupt ]
 
   # Create instance: AXIGate_0, and set properties
@@ -118,6 +122,7 @@ if {$maxi_ports == 2} {
  ] [get_bd_intf_pins /RVController_0/saxi]
 
   # Create instance: axi_interconnect_0, and set properties
+  # Connects the AXI4-Lite AXI_CTRL ports -> Smartconnect will be in Low-Area mode (no FIFOs)
   set axi_interconnect_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 axi_interconnect_0 ]
   set_property -dict [ list \
    CONFIG.NUM_MI {1} \

--- a/common/place_tapasco_control.tcl
+++ b/common/place_tapasco_control.tcl
@@ -118,10 +118,12 @@ if {$maxi_ports == 2} {
  ] [get_bd_intf_pins /RVController_0/saxi]
 
   # Create instance: axi_interconnect_0, and set properties
-  set axi_interconnect_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_interconnect:2.1 axi_interconnect_0 ]
+  set axi_interconnect_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 axi_interconnect_0 ]
   set_property -dict [ list \
    CONFIG.NUM_MI {1} \
    CONFIG.NUM_SI {2} \
+   CONFIG.NUM_CLKS {1} \
+   CONFIG.HAS_ARESETN {1} \
  ] $axi_interconnect_0
  
  # Create instance: dmaOffset, and set properties

--- a/riscv_pe_project.tcl
+++ b/riscv_pe_project.tcl
@@ -94,6 +94,8 @@ proc cr_bd_riscv_pe { parentCell lmem } {
   variable project_name
   variable cache
   variable maxi_ports
+  variable core_localmem
+  variable versal_embmem
   # CHANGE DESIGN NAME HERE
   set design_name ${project_name}
 

--- a/riscv_pe_project.tcl
+++ b/riscv_pe_project.tcl
@@ -133,6 +133,7 @@ proc cr_bd_riscv_pe { parentCell lmem } {
   # Set parent object as current
   current_bd_instance $parentObj
 
+  source common/bus_util.tcl
 
   source common/place_tapasco_control.tcl
 

--- a/riscv_pe_project.tcl
+++ b/riscv_pe_project.tcl
@@ -94,7 +94,6 @@ proc cr_bd_riscv_pe { parentCell lmem } {
   variable project_name
   variable cache
   variable maxi_ports
-  variable core_localmem
   variable versal_embmem
   # CHANGE DESIGN NAME HERE
   set design_name ${project_name}

--- a/specific_tcl/cva5_pe_project.tcl
+++ b/specific_tcl/cva5_pe_project.tcl
@@ -5,6 +5,9 @@ set cpu_clk [get_bd_pins cva5_0/clk]
 # Create interface connections
 set axi_io_port [get_bd_intf_pins cva5_0/m_axi]
 set axi_mem_port [get_bd_intf_pins cva5_0/m_axi_cache]
+connect_bd_intf_net -intf_net cva5_axi_mem $axi_mem_port [get_bd_intf_pins axi_mem_intercon_1/S00_AXI]
+set data_width [get_property CONFIG.DATA_WIDTH [get_bd_intf_pins cva5_0/m_axi_cache]]
+set addr_width [get_property CONFIG.ADDR_WIDTH [get_bd_intf_pins cva5_0/m_axi_cache]]
 
 set ibram [get_bd_intf_pins cva5_0/instruction_bram]
 set dbram [get_bd_intf_pins cva5_0/data_bram]

--- a/specific_tcl/cva6_pe_project.tcl
+++ b/specific_tcl/cva6_pe_project.tcl
@@ -42,13 +42,22 @@
 
   # Create interface connections
   #TODO this core has a single axi interface for both memories and peripherals
-  set cva6_mem_splitter [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_interconnect:2.1 cva6_mem_splitter ]
+  set cva6_mem_splitter [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 cva6_mem_splitter ]
   set_property CONFIG.NUM_MI 4 [get_bd_cells /cva6_mem_splitter]
   set_property CONFIG.NUM_SI 2 [get_bd_cells /cva6_mem_splitter]
+  set_property CONFIG.ADVANCED_PROPERTIES {} [get_bd_cells /cva6_mem_splitter]
+  set_bus_buffer_fifos [get_bd_cells /cva6_mem_splitter] S00_Buffer 4 4 4 4 4
+  set_bus_buffer_fifos [get_bd_cells /cva6_mem_splitter] S01_Buffer 4 4 4 4 4
+  set_bus_buffer_fifos [get_bd_cells /cva6_mem_splitter] M00_Buffer 4 4 4 4 4
+  set_bus_buffer_fifos [get_bd_cells /cva6_mem_splitter] M01_Buffer 4 4 4 4 4
+  set_bus_buffer_fifos [get_bd_cells /cva6_mem_splitter] M02_Buffer 4 4 4 4 4
+  set_bus_buffer_fifos [get_bd_cells /cva6_mem_splitter] M03_Buffer 4 4 4 4 4
 
   # Axi masters
   connect_bd_intf_net [get_bd_intf_pins cva6_0/io_axi_mem] -boundary_type upper [get_bd_intf_pins cva6_mem_splitter/S00_AXI]
   connect_bd_intf_net [get_bd_intf_pins cva6_dm_0/axi_dm_master] -boundary_type upper [get_bd_intf_pins cva6_mem_splitter/S01_AXI]
+  set data_width [get_property CONFIG.DATA_WIDTH [get_bd_intf_pins cva6_dm_0/axi_dm_master]]
+  set addr_width [get_property CONFIG.ADDR_WIDTH [get_bd_intf_pins cva6_dm_0/axi_dm_master]]
 
   # Axi slaves
   connect_bd_intf_net -boundary_type upper [get_bd_intf_pins cva6_mem_splitter/M00_AXI] [get_bd_intf_pins cva6_timer_0/axi_timer]
@@ -56,9 +65,8 @@
   connect_bd_intf_net -boundary_type upper [get_bd_intf_pins cva6_mem_splitter/M01_AXI] [get_bd_intf_pins axi_mem_intercon_1/S00_AXI]
   #connect_bd_intf_net -boundary_type upper [get_bd_intf_pins cva6_mem_splitter/M02_AXI] [get_bd_intf_pins rv_imem_ctrl/S_AXI]
   # Connect clocks
-  connect_bd_net [get_bd_ports CLK] [get_bd_pins cva6_mem_splitter/ACLK] [get_bd_pins cva6_mem_splitter/S00_ACLK] [get_bd_pins cva6_mem_splitter/M00_ACLK] [get_bd_pins cva6_mem_splitter/M01_ACLK] [get_bd_pins cva6_mem_splitter/M02_ACLK] [get_bd_pins cva6_mem_splitter/M03_ACLK] [get_bd_pins cva6_mem_splitter/S01_ACLK]
+  connect_bd_net [get_bd_ports CLK] [get_bd_pins cva6_mem_splitter/ACLK]
   connect_bd_net [get_bd_pins rst_CLK_100M/interconnect_aresetn] [get_bd_pins cva6_mem_splitter/ARESETN]
-  connect_bd_net [get_bd_pins rst_CLK_100M/peripheral_aresetn] [get_bd_pins cva6_mem_splitter/S00_ARESETN] [get_bd_pins cva6_mem_splitter/M00_ARESETN] [get_bd_pins cva6_mem_splitter/M01_ARESETN] [get_bd_pins cva6_mem_splitter/M02_ARESETN] [get_bd_pins cva6_mem_splitter/M03_ARESETN] [get_bd_pins cva6_mem_splitter/S01_ARESETN]
 
   # imem connection is done via the iaxi variable
   set iaxi [get_bd_intf_pins cva6_mem_splitter/M02_AXI]
@@ -138,10 +146,12 @@ proc create_specific_addr_segs {} {
   # Create specific address segments
   create_bd_addr_seg -range 0x00010000 -offset 0x11000000 [get_bd_addr_spaces cva6_0/io_axi_mem] [get_bd_addr_segs RVController_0/saxi/reg0] SEG_RVController_0_reg0
   create_bd_addr_seg -range 0x00010000 -offset 0x11000000 [get_bd_addr_spaces cva6_dm_0/axi_dm_master] [get_bd_addr_segs RVController_0/saxi/reg0] SEG_RVController_0_reg0
-  create_bd_addr_seg -range $DMEM_LENGTH -offset $DMEM_BASE [get_bd_addr_spaces cva6_0/io_axi_mem] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
-  create_bd_addr_seg -range $DMEM_LENGTH -offset $DMEM_BASE [get_bd_addr_spaces cva6_dm_0/axi_dm_master] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
-  create_bd_addr_seg -range $IMEM_LENGTH -offset $IMEM_BASE [get_bd_addr_spaces cva6_0/io_axi_mem] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
-  create_bd_addr_seg -range $IMEM_LENGTH -offset $IMEM_BASE [get_bd_addr_spaces cva6_dm_0/axi_dm_master] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  if {$lmem > 0} {
+    create_bd_addr_seg -range $DMEM_LENGTH -offset $DMEM_BASE [get_bd_addr_spaces cva6_0/io_axi_mem] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
+    create_bd_addr_seg -range $DMEM_LENGTH -offset $DMEM_BASE [get_bd_addr_spaces cva6_dm_0/axi_dm_master] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
+    create_bd_addr_seg -range $IMEM_LENGTH -offset $IMEM_BASE [get_bd_addr_spaces cva6_0/io_axi_mem] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+    create_bd_addr_seg -range $IMEM_LENGTH -offset $IMEM_BASE [get_bd_addr_spaces cva6_dm_0/axi_dm_master] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  }
 
   # Additional address sections for DM and timer
   # Timer

--- a/specific_tcl/flute32_pe_project.tcl
+++ b/specific_tcl/flute32_pe_project.tcl
@@ -16,6 +16,7 @@
  ] [get_bd_intf_pins /flute32_0/cpu_imem_master]
 
   # Create interface connections
+  set axi_mem_port [get_bd_intf_pins flute32_0/core_mem_master]
   connect_bd_intf_net -intf_net flute32_0_dmem_master [get_bd_intf_pins axi_mem_intercon_1/S00_AXI] [get_bd_intf_pins flute32_0/core_mem_master]
   set iaxi [get_bd_intf_pins flute32_0/cpu_imem_master]
 
@@ -30,8 +31,10 @@ proc create_specific_addr_segs {} {
   variable lmem
   # Create address segments
   create_bd_addr_seg -range 0x00010000 -offset 0x11000000 [get_bd_addr_spaces flute32_0/core_mem_master] [get_bd_addr_segs RVController_0/saxi/reg0] SEG_RVController_0_reg0
-  create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces flute32_0/core_mem_master] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
-  create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces flute32_0/cpu_imem_master] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  if { $lmem > 0 } {
+    create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces flute32_0/core_mem_master] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
+    create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces flute32_0/cpu_imem_master] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  }
 }
 
 proc get_external_mem_addr_space {} {

--- a/specific_tcl/orca_pe_project.tcl
+++ b/specific_tcl/orca_pe_project.tcl
@@ -30,6 +30,7 @@
       CONFIG.UC_MEMORY_REGIONS {0} \
     ] $orca_0
     set iaxi [get_bd_intf_pins orca_0/IC]
+    set axi_mem_port [get_bd_intf_pins orca_0/DC]
     connect_bd_intf_net [get_bd_intf_pins orca_0/DC] -boundary_type upper [get_bd_intf_pins axi_mem_intercon_1/S00_AXI]
   } else {
     set_property -dict [ list \
@@ -40,6 +41,7 @@
       CONFIG.INSTRUCTION_REQUEST_REGISTER {1} \
       CONFIG.UC_MEMORY_REGIONS {1} \
     ] $orca_0
+    set axi_mem_port [get_bd_intf_pins orca_0/DUC]
     connect_bd_intf_net -intf_net orca_0_DUC [get_bd_intf_pins orca_0/DUC] [get_bd_intf_pins axi_mem_intercon_1/S00_AXI]
     set iaxi [get_bd_intf_pins orca_0/IUC]
   }
@@ -50,12 +52,16 @@ proc create_specific_addr_segs {} {
   # Create address segments
   if { $cache } {
     create_bd_addr_seg -range 0x00010000 -offset 0x11000000 [get_bd_addr_spaces orca_0/DC] [get_bd_addr_segs RVController_0/saxi/reg0] SEG_RVController_0_reg0
-    create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces orca_0/DC] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
-    create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces orca_0/IC] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+    if { $lmem > 0 } {
+        create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces orca_0/DC] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
+        create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces orca_0/IC] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+    }
   } else {
     create_bd_addr_seg -range 0x00010000 -offset 0x11000000 [get_bd_addr_spaces orca_0/DUC] [get_bd_addr_segs RVController_0/saxi/reg0] SEG_RVController_0_reg0
-    create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces orca_0/DUC] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
-    create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces orca_0/IUC] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+    if { $lmem > 0 } {
+        create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces orca_0/DUC] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
+        create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces orca_0/IUC] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+    }
   }
 }
 

--- a/specific_tcl/piccolo32_pe_project.tcl
+++ b/specific_tcl/piccolo32_pe_project.tcl
@@ -16,6 +16,7 @@
  ] [get_bd_intf_pins /piccolo_0/cpu_imem_master]
 
   # Create interface connections
+  set axi_mem_port [get_bd_intf_pins piccolo_0/core_mem_master]
   connect_bd_intf_net -intf_net piccolo_0_cpu_dmem_master [get_bd_intf_pins axi_mem_intercon_1/S00_AXI] [get_bd_intf_pins piccolo_0/cpu_dmem_master]
   set iaxi [get_bd_intf_pins piccolo_0/cpu_imem_master]
   
@@ -39,8 +40,10 @@ proc create_specific_addr_segs {} {
   variable lmem
   # Create specific address segments
   create_bd_addr_seg -range 0x00010000 -offset 0x11000000 [get_bd_addr_spaces piccolo_0/cpu_dmem_master] [get_bd_addr_segs RVController_0/saxi/reg0] SEG_RVController_0_reg0
-  create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces piccolo_0/cpu_dmem_master] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
-  create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces piccolo_0/cpu_imem_master] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  if { $lmem > 0 } {
+    create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces piccolo_0/cpu_dmem_master] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
+    create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces piccolo_0/cpu_imem_master] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  }
 }
 
 proc get_external_mem_addr_space {} {

--- a/specific_tcl/picorv32_pe_project.tcl
+++ b/specific_tcl/picorv32_pe_project.tcl
@@ -11,6 +11,7 @@
  ] [get_bd_intf_pins /picorv32_0/mem_axi]
 
   # PicoRV32 only has one AXI master port, attach both memories to axi_mem_intercon_1
+  set axi_mem_port [get_bd_intf_pins piccolo_0/core_mem_master]
   connect_bd_intf_net [get_bd_intf_pins picorv32_0/mem_axi] [get_bd_intf_pins axi_mem_intercon_1/S00_AXI]
 
   # Create port connections
@@ -22,8 +23,10 @@ proc create_specific_addr_segs {} {
   variable lmem
   # Create address segments
   create_bd_addr_seg -range 0x00010000 -offset 0x11000000 [get_bd_addr_spaces picorv32_0/mem_axi] [get_bd_addr_segs RVController_0/saxi/reg0] SEG_RVController_0_reg0
-  create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces picorv32_0/mem_axi] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
-  create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces picorv32_0/mem_axi] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  if { $lmem > 0 } {
+    create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces picorv32_0/mem_axi] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
+    create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces picorv32_0/mem_axi] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  }
 }
 
 proc get_external_mem_addr_space {} {

--- a/specific_tcl/scr1_pe_project.tcl
+++ b/specific_tcl/scr1_pe_project.tcl
@@ -3,6 +3,7 @@
   set cpu_clk [get_bd_pins scr1_0/clk]
 
   # Create interface connections
+  set axi_mem_port [get_bd_intf_pins scr1_0/io_axi_dmem]
   connect_bd_intf_net [get_bd_intf_pins axi_mem_intercon_1/S00_AXI] [get_bd_intf_pins scr1_0/io_axi_dmem]
   set iaxi [get_bd_intf_pins scr1_0/io_axi_imem]
   
@@ -77,8 +78,10 @@ proc create_specific_addr_segs {} {
   variable lmem
   # Create specific address segments
   create_bd_addr_seg -range 0x00010000 -offset 0x11000000 [get_bd_addr_spaces scr1_0/io_axi_dmem] [get_bd_addr_segs RVController_0/saxi/reg0] SEG_RVController_0_reg0
-  create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces scr1_0/io_axi_dmem] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
-  create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces scr1_0/io_axi_imem] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  if { $lmem > 0 } {
+    create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces scr1_0/io_axi_dmem] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
+    create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces scr1_0/io_axi_imem] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  }
 }
 
 proc get_external_mem_addr_space {} {

--- a/specific_tcl/swerv_eh2_pe_project.tcl
+++ b/specific_tcl/swerv_eh2_pe_project.tcl
@@ -3,6 +3,7 @@
   set cpu_clk [get_bd_pins swerv_eh2_0/clk]
 
   # Create interface connections
+  set axi_mem_port [get_bd_intf_pins swerv_eh2_0/lsu_axi]
   connect_bd_intf_net [get_bd_intf_pins axi_mem_intercon_1/S00_AXI] [get_bd_intf_pins swerv_eh2_0/lsu_axi]
   set iaxi [get_bd_intf_pins swerv_eh2_0/ifu_axi]
   
@@ -94,8 +95,10 @@ proc create_specific_addr_segs {} {
   variable lmem
   # Create specific address segments
   create_bd_addr_seg -range 0x00010000 -offset 0x11000000 [get_bd_addr_spaces swerv_eh2_0/lsu_axi] [get_bd_addr_segs RVController_0/saxi/reg0] SEG_RVController_0_reg0
-  create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces swerv_eh2_0/lsu_axi] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
-  create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces swerv_eh2_0/ifu_axi] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  if { $lmem > 0 } {
+    create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces swerv_eh2_0/lsu_axi] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
+    create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces swerv_eh2_0/ifu_axi] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  }
 }
 
 proc get_external_mem_addr_space {} {

--- a/specific_tcl/swerv_pe_project.tcl
+++ b/specific_tcl/swerv_pe_project.tcl
@@ -3,6 +3,7 @@
   set cpu_clk [get_bd_pins swerv_0/clk]
 
   # Create interface connections
+  set axi_mem_port [get_bd_intf_pins swerv_0/lsu_axi]
   connect_bd_intf_net [get_bd_intf_pins axi_mem_intercon_1/S00_AXI] [get_bd_intf_pins swerv_0/lsu_axi]
   set iaxi [get_bd_intf_pins swerv_0/ifu_axi]
   
@@ -31,8 +32,10 @@ proc create_specific_addr_segs {} {
   variable lmem
   # Create specific address segments
   create_bd_addr_seg -range 0x00010000 -offset 0x11000000 [get_bd_addr_spaces swerv_0/lsu_axi] [get_bd_addr_segs RVController_0/saxi/reg0] SEG_RVController_0_reg0
-  create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces swerv_0/lsu_axi] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
-  create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces swerv_0/ifu_axi] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  if { $lmem > 0 } {
+    create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces swerv_0/lsu_axi] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
+    create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces swerv_0/ifu_axi] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  }
 }
 
 proc get_external_mem_addr_space {} {

--- a/specific_tcl/vexriscv_pe_project.tcl
+++ b/specific_tcl/vexriscv_pe_project.tcl
@@ -16,6 +16,7 @@
  ] [get_bd_intf_pins /VexRiscvAxi4_0/iBusAxi]
 
   # Create interface connections
+  set axi_mem_port [get_bd_intf_pins VexRiscvAxi4_0/dBusAxi]
   connect_bd_intf_net -intf_net VexRiscvAxi4_0_dBusAxi [get_bd_intf_pins VexRiscvAxi4_0/dBusAxi] [get_bd_intf_pins axi_mem_intercon_1/S00_AXI]
   set iaxi [get_bd_intf_pins VexRiscvAxi4_0/iBusAxi]
 
@@ -27,8 +28,10 @@ proc create_specific_addr_segs {} {
   variable lmem
   # Create address segments
   create_bd_addr_seg -range 0x00010000 -offset 0x11000000 [get_bd_addr_spaces VexRiscvAxi4_0/dBusAxi] [get_bd_addr_segs RVController_0/saxi/reg0] SEG_RVController_0_reg0
-  create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces VexRiscvAxi4_0/dBusAxi] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
-  create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces VexRiscvAxi4_0/iBusAxi] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  if { $lmem > 0 } {
+    create_bd_addr_seg -range $lmem -offset $lmem [get_bd_addr_spaces VexRiscvAxi4_0/dBusAxi] [get_bd_addr_segs rv_dmem_ctrl/S_AXI/Mem0] SEG_rv_dmem_ctrl_Mem0
+    create_bd_addr_seg -range $lmem -offset 0x00000000 [get_bd_addr_spaces VexRiscvAxi4_0/iBusAxi] [get_bd_addr_segs rv_imem_ctrl/S_AXI/Mem0] SEG_rv_imem_ctrl_Mem0
+  }
 }
 
 proc get_external_mem_addr_space {} {


### PR DESCRIPTION
Addresses some issues related to Versal (V80) with Vivado 2024.2.

- Rename SizedFIFO modules in AXIGate, Controller to avoid some name clash issues (that only manifest in some scenarios?)
- Use Smartconnect in place of Interconnect v2: Deprecation of the latter, missing Versal support
- Use emb_mem_gen (Versal-only) in place of blk_mem_gen (7-series to UltraScale+)

Unrelated: Allow disabling local memory (note: will likely have to fix the reset/boot PC setting somewhere in the core's files)

For Versal boards, the Makefile variables PYNQ, TAPASCO_PLATFORM, VERSAL need to be set accordingly.

- [x] Set data_width, addr_width for each core, or find an alternative to retrieving DATA_WIDTH/ADDR_WIDTH from the interconnect master.
- [x] The Smartconnects are not connected to peripheral_reset, as they do not have per-port reset pins. Is this a problem?
- [ ] Test synthesis for more cores (tested: CVA5, CVA6)
- [x] Test a bitstream (so far AU280)